### PR TITLE
no parallelization is faster in this case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ project/plugins/project/
 /.project
 /.settings/
 
+.idea/*

--- a/src/main/scala/threesbrain/neuralnetwork/GeneticAlgorithm.scala
+++ b/src/main/scala/threesbrain/neuralnetwork/GeneticAlgorithm.scala
@@ -29,7 +29,7 @@ object GeneticAlgorithm {
         println("Epoch        Best       Worst    Average")
 
         def epoch(population: List[Genome]): List[Genome] = {
-            val scores = population.par.map(genome => scoreFun(NeuralNetwork.fromWeights(layerSizes, genome)))
+            val scores = population.map(genome => scoreFun(NeuralNetwork.fromWeights(layerSizes, genome)))
             val (max, min, avg) = (scores.max, scores.min, scores.sum/scores.length)
             log.write(s"$max,$min,$avg\n")
             log.flush


### PR DESCRIPTION
parallelization makes it slower in this case.
with .par: ~60s per epoch
without .par: ~3s per epoch
